### PR TITLE
Remove hardcoded serial device

### DIFF
--- a/main.py
+++ b/main.py
@@ -2,44 +2,33 @@
 
 import sys
 import curses
+from curses import wrapper
 import serial  # pip install pyserial
 
-if len(sys.argv) != 2:
-    print("usage: {} serialdevice".format(sys.argv[0]))
-    exit(1)
-
-try:
-    s = serial.Serial(sys.argv[1], baudrate=19200)
-except serial.serialutil.SerialException as err:
-    print("Error while trying to open device {}: {}".format(sys.argv[1], err))
-    exit(1)
-scr = curses.initscr()
-curses.noecho()
-
-klawisz_na_opis = {
-    '\n': 'Enter',
-    'D': 'Lewo',
-    'C': 'Prawo',
-    'B': 'Dol',
-    'A': 'Gora',
+keylabels = {
+    chr(curses.KEY_RIGHT): 'Right',
+    chr(curses.KEY_LEFT): 'Left',
+    chr(curses.KEY_UP): 'Up',
+    chr(curses.KEY_DOWN): 'Down',
+    '\n': 'Enter'
 }
 
-klawisz_na_komende = {
-    '\n': 'C00',
+keys = {
+    'w': 'C00',
     'q': 'C01',
     '1': 'C05',
     '2': 'C06',
-    'm': 'C1C',
-    'c': 'C1D',
-    # tak naprawde to sa escape sequences i to dziala raczej przez przypadek
-    'D': 'C3B',
-    'C': 'C3A',
-    'A': 'C3C',
-    'B': 'C3D',
-    ' ': 'C3F',
+    's': 'C1C',
+    'a': 'C1D',
+    chr(curses.KEY_RIGHT): 'C3A',
+    chr(curses.KEY_LEFT): 'C3B',
+    chr(curses.KEY_UP): 'C3C',
+    chr(curses.KEY_DOWN): 'C3D',
+    '\n': 'C3F',
+    'x': 'x'
 }
 
-komenda_na_opis = {
+commands = {
     'C00': 'Power ON',
     'C01': 'Power OFF',
     'C05': 'Computer 1',
@@ -51,34 +40,53 @@ komenda_na_opis = {
     'C3C': 'Pointer up',
     'C3D': 'Pointer down',
     'C3F': 'Enter',
+    'x': 'Exit'
 }
 
-
-def generuj_instrukcje():
-    opisy_klawiszy = {chr(getattr(curses, x)): x[4:]
+def usage():
+    key_descriptions = {chr(getattr(curses, x)): x[4:]
                       for x in dir(curses) if x.startswith('KEY_')}
     ret = ''
-    for klawisz, komenda in klawisz_na_komende.items():
-        opis_klawisza = None
-        if opis_klawisza is None:
-            opis_klawisza = klawisz_na_opis.get(klawisz)
-        if opis_klawisza is None:
-            opis_klawisza = opisy_klawiszy.get(klawisz)
-        if opis_klawisza is None:
-            opis_klawisza = klawisz if klawisz.isalnum() else repr(klawisz)
-        opis_komendy = komenda_na_opis[komenda]
-        ret += f'{opis_klawisza}: {opis_komendy}'
+
+    for known_key, command in keys.items():
+        key_description = None
+        if known_key in keylabels.keys():
+            key_description = keylabels.get(known_key)
+        if key_description is None:
+            key_description = known_key if str(known_key).isalnum() else repr(known_key)
+        cmd_description = commands.get(command)
+        ret += f'{key_description}: {cmd_description}'
         if ret:
             ret += '\n'
     return ret
 
+def main(scr):
+    char = '\0'
 
-char = '.'
-while True:
-    scr.clear()
-    scr.addstr(0, 0, 'Kod klawisza: ' + str(ord(char)) +
-               '\n\n' + generuj_instrukcje())
-    char = chr(scr.getch())
-    komenda = klawisz_na_komende.get(char)
-    if komenda:
-        s.write(komenda.encode() + b'\r\n')
+    if len(sys.argv) != 2:
+        print("usage: {} serialdevice".format(sys.argv[0]))
+        quit(1)
+
+    try:
+        s = serial.Serial(sys.argv[1], baudrate=19200)
+    except serial.serialutil.SerialException as err:
+        print("Error while trying to open device {}: {}".format(sys.argv[1], err))
+        quit(1)
+
+    curses.noecho()
+
+    while True:
+        scr.clear()
+        scr.addstr(0, 0, 'Last key: ' + str(ord(char)) +
+               '\n\n' + usage())
+        char = chr(scr.getch())
+        if char == 'x':
+            curses.endwin()
+            quit(0)
+        else:
+            command = keys.get(char)
+            if command:
+                s.write(command.encode() + b'\r\n')
+
+if __name__ == "__main__":
+    wrapper(main)

--- a/main.py
+++ b/main.py
@@ -1,9 +1,18 @@
 #!/usr/bin/env python
 
+import sys
 import curses
 import serial  # pip install pyserial
 
-s = serial.Serial('/dev/ttyUSB1', baudrate=19200)
+if len(sys.argv) != 2:
+    print("usage: {} serialdevice".format(sys.argv[0]))
+    exit(1)
+
+try:
+    s = serial.Serial(sys.argv[1], baudrate=19200)
+except serial.serialutil.SerialException as err:
+    print("Error while trying to open device {}: {}".format(sys.argv[1], err))
+    exit(1)
 scr = curses.initscr()
 curses.noecho()
 


### PR DESCRIPTION
Instead add path to device as an argument: `./main.py /dev/ttyUSB1` (Unix) or `./main.py COM9` (Windows)